### PR TITLE
v0.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tauri-sveltekit",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"private": true,
 	"scripts": {
 		"dev": "npm run tauri dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Minetest Launcher",
-    "version": "0.0.2"
+    "version": "0.0.3"
   },
   "tauri": {
     "allowlist": {
@@ -47,6 +47,8 @@
           "https://servers.minetest.net/list",
           "https://github.com/minetest/minetest/releases/download/*",
           "https://api.github.com/repos/minetest/minetest/releases",
+          "https://api.github.com/repos/An0n3m0us/Minetest-AppImages/releases",
+          "https://api.github.com/repos/An0n3m0us/Minetest-AppImages/download/*",
           "https://blog.minetest.net/feed.rss",
           "https://content.minetest.net/api/*"
         ]

--- a/src/lib/shell.js
+++ b/src/lib/shell.js
@@ -3,25 +3,31 @@ import { type, arch } from '@tauri-apps/api/os';
 import { appDir } from "@tauri-apps/api/path";
 import { invoke } from '@tauri-apps/api/tauri';
 
+export async function getVersionFolder(version) {
+    let baseDir = await appDir();
+
+    return `${baseDir}/versions/${version}`;
+}
+
 export async function getBinaryLocation(version) {
     let [ platform, osArch, baseDir ] = await Promise.all([
         type(),
         arch(),
-        appDir()
+        getVersionFolder(version)
     ]);
 
     switch (platform) {
         case 'Linux':
-            return `${baseDir}/versions/${version}/minetest.AppImage`;
+            return `${baseDir}/minetest.AppImage`;
 
         case 'Darwin':
-            return `${baseDir}/versions/${version}/minetest.app`;
+            return `${baseDir}/minetest.app`;
 
         case 'Windows_NT':
-            return `${baseDir}/versions/${version}/bin/minetest.exe`;
+            return `${baseDir}/bin/minetest.exe`;
     }
 
-    return `${baseDir}/versions/${version}/minetest`;
+    return `${baseDir}/minetest`;
 }
 
 export async function openServer(server, username, password, version = '5.6.0') {
@@ -70,10 +76,12 @@ export async function openWorld(worldName, version = '5.6.0') {
 }
 
 async function openMinetest(version, args) {
-    let dir = await getBinaryLocation(version);
+    let binary = await getBinaryLocation(version);
+    let baseDir = await getVersionFolder(version);
 
     await invoke('open_minetest', {
-        loc: dir,
+        loc: binary,
+        contentDir: baseDir,
         args: args
     });
 }


### PR DESCRIPTION
- adding in new download source for AppImages: An0n3m0us/Minetest-AppImages
- showing only the installable versions based on your OS
- ensuring that MT loads content in the launcher directory, rather than using default dirs for linux/macos